### PR TITLE
feat: added support for preloading images

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
   - [Custom Picture component](#Custompicturecomponent)
   - [Configuring the CMS](#configuringTheCms)
   - [Astro Content Collections](#AstroContentCollections)
+  - [Preloading images](#preloadingimages)
 - [Deployment](#deployment)
 - [Conclusion](#conclusion)
 
@@ -559,6 +560,23 @@ This template already has Content Collections configured for immediate use of th
 
 Content Collections can also be used on content that is not created via the CMS.
 
+<a name="preloadingimages"></a>
+
+### Preloading images
+THis kit takes advantage of the [preload attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/preload) to fetch images above the fold with higher priority, resulting in improved performances and reducing flashes of unstyled content. Preloaded images are used on the index page for the hero image as well as on all other pages in the Landing component.
+
+You will notice this snippet at the top of every `.astro` page:
+
+```jsx
+---
+// Optimize our landing image and pass it as props to the BaseLayout (for preloading) and Landing (for rendering)
+import {getOptimizedImage} from "../js/utils"
+import landingImage from "../assets/images/landing.jpg" // <-- THE PATH TO THE ASSET YOU WANT TO PRELOAD - The asset must live in src
+const optimizedImage = await getOptimizedImage(landingImage)
+---
+```
+
+You only need to change the path of the asset you want to preload. The rest is managed behind the scenes.
 
 <a name="deployment"></a>
 

--- a/src/components/Landing.astro
+++ b/src/components/Landing.astro
@@ -1,15 +1,17 @@
 ---
 import Picture from "astro/components/Picture.astro"
-import landingImage from "@assets/images/landing.jpg" // The asset must be imported from src in order to be used in <Picture /> or <Image />
-const { title } = Astro.props
+const { title, image } = Astro.props
 ---
 
 <section id="int-hero">
 <h1 id="home-h">{title}</h1>
 
 <!-- standard <picture> attributes are supported. Set loading to lazy for assets below the fold -->
-<Picture 
-    src={landingImage}
+ <!-- Note: because we use the getImage function to generate an optimized image, we need to use special properties. More info on [the getImage() page](https://docs.astro.build/en/guides/images/#generating-images-with-getimage) -->
+ <Picture 
+    src={image.src}
+    width={image.attributes.width}
+    height={image.attributes.height}
     formats={['avif', 'webp']} 
     alt="A description of my image."
     aria-hidden="true" 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -6,7 +6,7 @@ import Footer from "@components/Footer.astro";
 import "@styles/root.less";
 import "@styles/dark.less";
 
-const {description, title} = Astro.props;
+const { description, title, preloadedImage } = Astro.props;
 
 ---
 <!-- A fully fleshed-out <head>, dynamically changing based on client.json and the page front matter -->
@@ -22,7 +22,10 @@ const {description, title} = Astro.props;
             <meta name="description" content={description}>
             <meta name="keywords" content="">
             <link rel="canonical" href={`https://${client.domain}${Astro.url.pathname}`}>
-    
+
+            <!-- Preloads the image passed as a prop -->
+            <link rel="preload" href={preloadedImage.src} as="image" />
+
             <!--Social Media Display-->
             <meta property="og:title" content={title} />
             <meta property="og:description" content={description} />

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -10,3 +10,16 @@ export function formatDate(date) {
 export function getCurrentYear() {
   return new Date().getFullYear();
 }
+
+import { getImage } from "astro:assets";
+export async function getOptimizedImage(image) {
+  const optimizedImage = await getImage({
+    src: image,
+    format: "webp",
+  });
+
+  return optimizedImage
+}
+
+// Learn more agout the getImage() function here
+// https://docs.astro.build/en/guides/images/#generating-images-with-getimage

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -3,11 +3,17 @@ import BaseLayout from "src/layouts/BaseLayout.astro";
 import CTA from "@components/CTA.astro";
 import Landing from "@components/Landing.astro";
 import FAQ from "@components/FAQ.astro";
+
+// Optimize our landing image and pass it as props to the BaseLayout (for preloading) and Landing (for rendering)
+import {getOptimizedImage} from "@libs/utils"
+import landingImage from "@assets/images/landing.jpg" // <-- THE PATH TO THE ASSET YOU WANT TO PRELOAD - The asset must live in src
+const optimizedImage = await getOptimizedImage(landingImage)
 ---
 
 <BaseLayout
   title="About"
   description="Meta description for the page"
+  preloadedImage = {optimizedImage}
 >
   <!-- ============================================ -->
   <!--                    LANDING                   -->
@@ -15,6 +21,7 @@ import FAQ from "@components/FAQ.astro";
 
   <Landing 
     title="About Us"
+    image={optimizedImage}
   />
 
   <!-- ============================================ -->

--- a/src/pages/blog/[...post].astro
+++ b/src/pages/blog/[...post].astro
@@ -7,6 +7,11 @@ import Landing from "@components/Landing.astro";
 import FeaturedPost from "@components/FeaturedPost.astro";
 import "@styles/blog.less";
 
+// Optimize our landing image and pass it as props to the BaseLayout (for preloading) and Landing (for rendering)
+import {getOptimizedImage} from "@libs/utils"
+import landingImage from "@assets/images/landing.jpg" // <-- THE PATH TO THE ASSET YOU WANT TO PRELOAD - The asset must live in src
+const optimizedImage = await getOptimizedImage(landingImage)
+
 export async function getStaticPaths() {
   const posts = await getCollection("blog");
   return posts.map((entry) => ({
@@ -20,13 +25,15 @@ const { title, date, description, image, imageAlt, author } = post.data;
 const { Content } = await post.render();
 ---
 
-<BaseLayout {title} {description}>
-  <!-- ============================================ -->
-  <!--                    LANDING                   -->
-  <!-- ============================================ -->
+<BaseLayout
+  title={title}
+  description={description}
+  preloadedImage = {optimizedImage}
+>
 
   <Landing 
     title="Blog"
+    image={optimizedImage}
   />
 
   <!-- ============================================ -->

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -13,12 +13,17 @@ const posts = await getCollection("blog");
 posts.sort(
   (a, b) => new Date(b.data.date).valueOf() - new Date(a.data.date).valueOf()
 );
+
+// Optimize our landing image and pass it as props to the BaseLayout (for preloading) and Landing (for rendering)
+import {getOptimizedImage} from "@libs/utils"
+import landingImage from "@assets/images/landing.jpg" // <-- THE PATH TO THE ASSET YOU WANT TO PRELOAD - The asset must live in src
+const optimizedImage = await getOptimizedImage(landingImage)
 ---
 
 <BaseLayout
   title="Blog"
   description="Meta description for the page"
-  preloadImg="/assets/images/cabinets2.jpg"
+  preloadedImage = {optimizedImage}
 >
   <!-- ============================================ -->
   <!--                    LANDING                   -->
@@ -26,6 +31,7 @@ posts.sort(
 
   <Landing 
     title="Blog"
+    image={optimizedImage}
   />
 
   <!-- ============================================ -->

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -3,11 +3,16 @@ import BaseLayout from "src/layouts/BaseLayout.astro";
 import client from "@data/client.json";
 import Landing from "@components/Landing.astro";
 
+// Optimize our landing image and pass it as props to the BaseLayout (for preloading) and Landing (for rendering)
+import {getOptimizedImage} from "@libs/utils"
+import landingImage from "@assets/images/landing.jpg" // <-- THE PATH TO THE ASSET YOU WANT TO PRELOAD - The asset must live in src
+const optimizedImage = await getOptimizedImage(landingImage)
 ---
 
 <BaseLayout
   title="Contact"
   description="Meta description for the page"
+  preloadedImage = {optimizedImage}
 >
   <!-- ============================================ -->
   <!--                    LANDING                   -->
@@ -15,6 +20,7 @@ import Landing from "@components/Landing.astro";
 
   <Landing 
     title="Contact"
+    image={optimizedImage}
   />
 
   <!-- ============================================ -->

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,11 +2,17 @@
 import BaseLayout from "src/layouts/BaseLayout.astro";
 import CTA from "@components/CTA.astro";
 import FAQ from "@components/FAQ.astro";
+
+// Optimize our landing image and pass it as props to the BaseLayout (for preloading) and Landing (for rendering)
+import {getOptimizedImage} from "@libs/utils"
+import landingImage from "@assets/images/landing.jpg" // <-- THE PATH TO THE ASSET YOU WANT TO PRELOAD - The asset must live in src
+const optimizedImage = await getOptimizedImage(landingImage)
 ---
 
 <BaseLayout
   title="Pixel Perfect Websites"
   description="Meta description for the page"
+  preloadedImage = {optimizedImage}
 >
   <!-- ============================================ -->
   <!--                    Hero                      -->
@@ -48,7 +54,7 @@ allows for repeated components, centralized data and greater room to scale as yo
       <img
         aria-hidden="true"
         decoding="async"
-        src="/assets/images/hero.jpg"
+        src={optimizedImage.src}
         alt="new home"
         width="2500"
         height="1667"

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -2,11 +2,16 @@
 import BaseLayout from "src/layouts/BaseLayout.astro";
 import CTA from "@components/CTA.astro";
 import Landing from "@components/Landing.astro";
+// Optimize our landing image and pass it as props to the BaseLayout (for preloading) and Landing (for rendering)
+import {getOptimizedImage} from "@libs/utils"
+import landingImage from "@assets/images/landing.jpg" // <-- THE PATH TO THE ASSET YOU WANT TO PRELOAD - The asset must live in src
+const optimizedImage = await getOptimizedImage(landingImage)
 ---
 
 <BaseLayout
   title="Projects"
   description="Meta description for the page"
+  preloadedImage = {optimizedImage}
 >
   <!-- ============================================ -->
   <!--                    LANDING                   -->
@@ -14,6 +19,7 @@ import Landing from "@components/Landing.astro";
 
   <Landing 
     title="All projects"
+    image={optimizedImage}
   />
 
   <!-- ============================================ -->

--- a/src/pages/projects/project-1.astro
+++ b/src/pages/projects/project-1.astro
@@ -2,11 +2,16 @@
 import BaseLayout from "src/layouts/BaseLayout.astro";
 import CTA from "@components/CTA.astro";
 import Landing from "@components/Landing.astro";
+// Optimize our landing image and pass it as props to the BaseLayout (for preloading) and Landing (for rendering)
+import {getOptimizedImage} from "@libs/utils"
+import landingImage from "@assets/images/landing.jpg" // <-- THE PATH TO THE ASSET YOU WANT TO PRELOAD - The asset must live in src
+const optimizedImage = await getOptimizedImage(landingImage)
 ---
 
 <BaseLayout
   title="Projects"
   description="Meta description for the page"
+  preloadedImage = {optimizedImage}
 >
   <!-- ============================================ -->
   <!--                    LANDING                   -->
@@ -14,6 +19,7 @@ import Landing from "@components/Landing.astro";
 
   <Landing 
     title="Project 1"
+    image={optimizedImage}
   />
 
   <!-- ============================================ -->

--- a/src/pages/projects/project-2.astro
+++ b/src/pages/projects/project-2.astro
@@ -2,11 +2,17 @@
 import BaseLayout from "src/layouts/BaseLayout.astro";
 import CTA from "@components/CTA.astro";
 import Landing from "@components/Landing.astro";
+
+// Optimize our landing image and pass it as props to the BaseLayout (for preloading) and Landing (for rendering)
+import {getOptimizedImage} from "@libs/utils"
+import landingImage from "@assets/images/landing.jpg" // <-- THE PATH TO THE ASSET YOU WANT TO PRELOAD - The asset must live in src
+const optimizedImage = await getOptimizedImage(landingImage)
 ---
 
 <BaseLayout
   title="Projects"
   description="Meta description for the page"
+  preloadedImage = {optimizedImage}
 >
   <!-- ============================================ -->
   <!--                    LANDING                   -->
@@ -14,6 +20,7 @@ import Landing from "@components/Landing.astro";
 
   <Landing 
     title="Project 2"
+    image={optimizedImage}
   />
 
   <!-- ============================================ -->

--- a/src/pages/reviews.astro
+++ b/src/pages/reviews.astro
@@ -2,11 +2,16 @@
 import BaseLayout from "src/layouts/BaseLayout.astro";
 import CTA from "@components/CTA.astro";
 import Landing from "@components/Landing.astro";
+// Optimize our landing image and pass it as props to the BaseLayout (for preloading) and Landing (for rendering)
+import {getOptimizedImage} from "@libs/utils"
+import landingImage from "@assets/images/landing.jpg" // <-- THE PATH TO THE ASSET YOU WANT TO PRELOAD - The asset must live in src
+const optimizedImage = await getOptimizedImage(landingImage)
 ---
 
 <BaseLayout
   title="Reviews"
   description="Meta description for the page"
+  preloadedImage = {optimizedImage}
 >
   <!-- ============================================ -->
   <!--                    LANDING                   -->
@@ -14,6 +19,7 @@ import Landing from "@components/Landing.astro";
 
   <Landing 
     title="Reviews"
+    image={optimizedImage}
   />
 
   <!-- ============================================ -->


### PR DESCRIPTION
This PR adds support for the [preload attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/preload) to fetch images above the fold with higher priority, resulting in improved performances and reducing flashes of unstyled content. Preloaded images are used on the index page for the hero image as well as on all other pages in the Landing component.

You will notice this snippet at the top of every `.astro` page:

```jsx
---
// Optimize our landing image and pass it as props to the BaseLayout (for preloading) and Landing (for rendering)
import {getOptimizedImage} from "../js/utils"
import landingImage from "../assets/images/landing.jpg" // <-- THE PATH TO THE ASSET YOU WANT TO PRELOAD - The asset must live in src
const optimizedImage = await getOptimizedImage(landingImage)
---
```

You only need to change the path of the asset you want to preload (e.g. `"../assets/images/landing.jpg"`). The rest is managed behind the scenes.