### PR TITLE
Feat: Add @astrojs/sitemap for automatic sitemap.xml generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 - [Project Structure](#projectStructure)
   - [Project Tree](#projectTree)
   - [Root Files and Folders](#rootFilesAndFolders)
+  - [Sitemap Configuration](#sitemapConfiguration)
 - [Expanding the Project](#expandingTheProject)
   - [Reusing Code](#reusingCode)
   - [Scripts and Event Handling](#scripts)
@@ -242,6 +243,36 @@ An Astro configuration file. It's already set up for you, but you can extend it 
 #### `tsconfig.json`
 A TypeScript configuration file. Optional. Includes TypeScript configuration options for your Astro project. Some features (like npm package imports) aren’t fully supported in the editor without a tsconfig.json file.
 
+<a name="sitemapConfiguration"></a>
+
+## Sitemap Configuration
+
+This template includes automatic sitemap generation using `@astrojs/sitemap`. The sitemap helps search engines better crawl and index your site.
+
+### Features
+- Automatically generates `sitemap-index.xml` and `sitemap-0.xml`
+- Excludes admin routes from indexing
+- No manual XML creation needed
+
+### Configuration
+The sitemap is pre-configured in `astro.config.mjs`. Here's what's included:
+
+```js
+import sitemap from '@astrojs/sitemap';
+
+export default defineConfig({
+  site: 'https://yourwebsite.com',  // Replace with your site URL
+  integrations: [
+    sitemap({
+      filter: (page) => !page.includes('/admin'),
+      changefreq: 'weekly',
+      priority: 0.7
+    })
+  ]
+});
+```
+
+> Note: Make sure to replace `https://yourwebsite.com` with your actual site URL.
 
 <a name="expandingTheProject"></a>
 

--- a/README.md
+++ b/README.md
@@ -169,12 +169,11 @@ Astro leverages an opinionated folder layout for your project. Every Astro proje
 #### `public/*`
 The `public/` directory is for files and assets in your project that do not need to be processed during Astro’s build process. The files in this folder will be copied into the build folder untouched, and then your site will be built.
 
-This behavior makes `public/` ideal for common assets like images and fonts, or special files such as`_redirects`, `robots.txt` and `sitemap.xml`.
+This behavior makes `public/` ideal for common assets like images and fonts, or special files such as`_redirects` and `robots.txt`.
 
 - \_redirects - To configure redirects. Read more on <a href="https://docs.netlify.com/routing/redirects/">Netlify</a>
 - content/ - Data to render pages from, such as the blog.
 - robots.txt - Instructions for site crawlers. Learn more, and generate your own, <a href="https://en.ryte.com/free-tools/robots-txt-generator/">here</a>
-- sitemap.xml - A map of the pages on the domain. Create your own after deployment <a href="https://www.xml-sitemaps.com/">here</a>
 
 You can place CSS and JavaScript in your public/ directory, but be aware that those files will not be bundled or optimized in your final build.
 
@@ -247,7 +246,7 @@ A TypeScript configuration file. Optional. Includes TypeScript configuration opt
 
 ## Sitemap Configuration
 
-This template includes automatic sitemap generation using `@astrojs/sitemap`. The sitemap helps search engines better crawl and index your site.
+This template includes automatic sitemap generation using <a href="https://docs.astro.build/en/guides/integrations-guide/sitemap/">`@astrojs/sitemap`</a>. The sitemap helps search engines better crawl and index your site.
 
 ### Features
 - Automatically generates `sitemap-index.xml` and `sitemap-0.xml`

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,8 +1,14 @@
 import { defineConfig } from 'astro/config';
+import sitemap from '@astrojs/sitemap';
 
 import icon from "astro-icon";
 
 // https://astro.build/config
 export default defineConfig({
-  integrations: [icon()]
+  site: 'https://www.yourwebsite.com',
+  integrations: [icon(), sitemap({
+    filter: (page) => !page.includes('/admin'),
+    changefreq: 'weekly',
+    priority: 0.7
+  })]
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@astrojs/check": "^0.9.4",
+        "@astrojs/sitemap": "^3.2.1",
         "astro": "^4.16.3",
         "astro-icon": "^1.1.1",
         "autoprefixer": "^10.4.20",
@@ -162,6 +163,17 @@
       },
       "engines": {
         "node": "^18.17.1 || ^20.3.0 || >=21.0.0"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.2.1.tgz",
+      "integrity": "sha512-uxMfO8f7pALq0ADL6Lk68UV6dNYjJ2xGUzyjjVj60JLBs5a6smtlkBYv3tQ0DzoqwS7c9n4FUx5lgv0yPo/fgA==",
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^8.0.0",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^3.23.8"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -1966,6 +1978,15 @@
         "undici-types": "~5.26.4"
       }
     },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/tar": {
       "version": "6.1.13",
       "resolved": "https://registry.npmjs.org/@types/tar/-/tar-6.1.13.tgz",
@@ -2211,6 +2232,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -7939,8 +7966,7 @@
     "node_modules/sax": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
-      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==",
-      "optional": true
+      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA=="
     },
     "node_modules/section-matter": {
       "version": "1.0.0",
@@ -8211,6 +8237,31 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
     },
+    "node_modules/sitemap": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-8.0.0.tgz",
+      "integrity": "sha512-+AbdxhM9kJsHtruUF39bwS/B0Fytw6Fr1o4ZAIAEqA6cke2xcoO2GleBw9Zw7nRzILVEgz7zBM5GiTJjie1G9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^17.0.5",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "sitemap": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/sitemap/node_modules/@types/node": {
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+      "license": "MIT"
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -8308,6 +8359,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@astrojs/check": "^0.9.4",
+    "@astrojs/sitemap": "^3.2.1",
     "astro": "^4.16.3",
     "astro-icon": "^1.1.1",
     "autoprefixer": "^10.4.20",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,4 +2,4 @@ User-agent: *
 Disallow: /admin/
 Allow: /
 
-Sitemap: https://www.yourwebsite.com/sitemap.xml
+Sitemap: https://www.yourwebsite.com/sitemap-index.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,1 +1,0 @@
-<!-- When you deploy the project to a live domain, go to www.xml-sitemaps.com, create a sitemap and paste the contents in here -->


### PR DESCRIPTION
This PR adds sitemap generation and proper search engine configurations to ensure better SEO for sites built with this template. This also helps for Decap CMS set up so when admins add blog posts this automatically will add the post to their sitemap.xml

Key changes:
* Added @astrojs/sitemap integration with configuration to exclude admin routes
* Added static robots.txt in /public with appropriate directives
* Updated astro.config.mjs with sitemap configuration
* Updated documentation in README.md to explain sitemap setup

The sitemap integration automatically generates `sitemap-index.xml` and `sitemap-0.xml` during build. To use it, developers only need to update their site URL in `astro.config.mjs`:

```js
site: 'https://yourwebsite.com',  // Replace with your site URL
integrations: [
  sitemap({
    filter: (page) => !page.includes('/admin'),
    changefreq: 'weekly',
    priority: 0.7
  })
]